### PR TITLE
Get finder working with multipe folders in the "copy-file" array

### DIFF
--- a/ScriptHandler.php
+++ b/ScriptHandler.php
@@ -26,7 +26,6 @@ class ScriptHandler
             throw new \InvalidArgumentException('The extra.copy-file must be hash like "{<dir_or_file_from>: <dir_to>}".');
         }
 
-        $finder = new Finder;
         $fs = new Filesystem;
         $io = $event->getIO();
 
@@ -46,6 +45,7 @@ class ScriptHandler
             }
 
             if (is_dir($from)) {
+                $finder = new Finder;
                 $finder->files()->in($from);
 
                 foreach ($finder as $file) {


### PR DESCRIPTION
## The problem was:
### With the folowing in the `composer.json`:
```
"extra": {
    "copy-file": {
        "vendor/[...]/folder1/": "webroot/[...]/folder1/",
        "vendor/[...]/folder2/": "webroot/[...]/folder2/",
        "vendor/[...]/folder3/": "webroot/[...]/folder3/"
    }
},
```
### After `composer update` you get the following:
- `webroot/[...]/folder1/`: files of `vendor/[...]/folder1/`
- `webroot/[...]/folder2/`: files of `vendor/[...]/folder1/` and `vendor/[...]/folder2/`
- `webroot/[...]/folder3/`: files of `vendor/[...]/folder1/`, `vendor/[...]/folder2/` and `vendor/[...]/folder3/`

That is so because `Finder` always adds the folders to the existign `Finder`-object.

**This PR creates for each folder element in the `copy-file` array a new `Finder`-object.**

