### PR TITLE
Include files beginning with dot

### DIFF
--- a/ScriptHandler.php
+++ b/ScriptHandler.php
@@ -53,7 +53,7 @@ class ScriptHandler
 
             if (is_dir($from)) {
                 $finder = new Finder;
-                $finder->files()->in($from);
+                $finder->files()->ignoreDotFiles(false)->in($from);
 
                 foreach ($finder as $file) {
                     $dest = sprintf('%s/%s', $to, $file->getRelativePathname());

--- a/tests/CopyFileTest.php
+++ b/tests/CopyFileTest.php
@@ -109,6 +109,7 @@ class CopyFileTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($root->hasChild('to/file4'));
         $this->assertFalse($root->hasChild('to/sub_dir/file5'));
+        $this->assertFalse($root->hasChild('to/git_keep_dir'));
 
         ScriptHandler::copy($this->getEventMock([
             vfsStream::url('root/from_complex')=> vfsStream::url('root/to')
@@ -116,6 +117,7 @@ class CopyFileTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($root->hasChild('to/file4'));
         $this->assertTrue($root->hasChild('to/sub_dir/file5'));
+        $this->assertTrue($root->hasChild('to/git_keep_dir'));
     }
 
     public function testConfigError()
@@ -208,7 +210,10 @@ class CopyFileTest extends PHPUnit_Framework_TestCase
                 'file4' => 'Some content',
                 'sub_dir' => [
                     'file5' => 'Some content',
-                ]
+                ],
+                'git_keep_dir' => [
+                    '.gitkeep' => '',
+                ],
             ],
         ];
 


### PR DESCRIPTION
Hi.

I used your script to copy whole folder structures with `.gitkeep` files inside. However by default Finder excludes all files beginning with `.`. As your script doesn't copy empty folders, the copied folders were always incomplete.

To resolve it I disabled flag `ignoreDotFiles` in Finder.