### PR TITLE
Add regexp source filter case

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,23 @@ dir/
             file1.txt - Not changed
             file2.txt - Replaced
     ```
+    
+5. Filter source files by regexp pattern
+
+    ```
+    {
+        "extra": {
+            "copy-file": {
+                "dir/subdir#1\.\w{3}$": "web/other/"
+            }
+        }
+    }
+    ```
+
+    Result:
+
+    ```
+    web/
+        other/
+            file1.txt
+    ```

--- a/ScriptHandler.php
+++ b/ScriptHandler.php
@@ -31,6 +31,12 @@ class ScriptHandler
         $io = $event->getIO();
 
         foreach ($files as $from => $to) {
+            // check pattern
+            $pattern = null;
+            if (strpos($from, '#') > 0) {
+                list($from, $pattern) = explode('#', $from, 2);
+            }
+
             // check the overwrite newer files disable flag (? in end of path)
             $overwriteNewerFiles = substr($to, -1) != '?';
             if (!$overwriteNewerFiles) {
@@ -61,6 +67,10 @@ class ScriptHandler
             if (is_dir($from)) {
                 $finder = new Finder;
                 $finder->files()->ignoreDotFiles(false)->in($from);
+
+                if ($pattern) {
+                    $finder->path("#{$pattern}#");
+                }
 
                 foreach ($finder as $file) {
                     $dest = sprintf('%s/%s', $to, $file->getRelativePathname());

--- a/tests/CopyFileTest.php
+++ b/tests/CopyFileTest.php
@@ -150,24 +150,4 @@ class CopyFileTest extends TestCase
         ScriptHandler::copy($this->getEventMock(null));
         ScriptHandler::copy($this->getEventMock('some string'));
     }
-
-    protected function getLeafs($array, $glue = '/')
-    {
-        $leafs = array();
-        if (!is_array($array)) {
-            return $leafs;
-        }
-        $array_iterator = new RecursiveArrayIterator($array);
-        $iterator_iterator = new RecursiveIteratorIterator($array_iterator, RecursiveIteratorIterator::LEAVES_ONLY);
-        foreach ($iterator_iterator as $key => $value) {
-            $keys = array();
-            for ( $i = 0; $i < $iterator_iterator->getDepth(); $i++ ) {
-                $keys[] = $iterator_iterator->getSubIterator($i)->key();
-            }
-            $keys[] = $key;
-            $leaf_key = implode($glue, $keys);
-            $leafs[$leaf_key] = $value;
-        }
-        return $leafs;
-    }
 }

--- a/tests/CopyFileTest.php
+++ b/tests/CopyFileTest.php
@@ -2,7 +2,6 @@
 
 use \SlowProg\CopyFile\ScriptHandler;
 use \org\bovigo\vfs\vfsStream;
-use \org\bovigo\vfs\visitor\vfsStreamStructureVisitor;
 
 class CopyFileTest extends TestCase
 {


### PR DESCRIPTION
For issue #10 

This feature allow filters source files relative paths by Perl-like regular expressions.
Expression delimited from base directory path by `#` character.

I fount [this feature](https://symfony.com/doc/current/components/finder.html#path) for it.